### PR TITLE
DF-0893 Enable custom cell creation

### DIFF
--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -192,6 +192,13 @@ class PlutoColumn {
   /// Hide the column.
   bool hide;
 
+  Widget? Function(
+    PlutoGridStateManager stateManager,
+    PlutoCell cell,
+    PlutoColumn column,
+    PlutoRow row,
+  )? customCell;
+
   PlutoColumn({
     required this.title,
     required this.field,
@@ -226,6 +233,7 @@ class PlutoColumn {
     this.enableAutoEditing = false,
     this.enableEditingMode = true,
     this.hide = false,
+    this.customCell,
   })  : _key = UniqueKey(),
         _checkReadOnly = checkReadOnly;
 

--- a/lib/src/model/pluto_column_type.dart
+++ b/lib/src/model/pluto_column_type.dart
@@ -4,6 +4,14 @@ import 'package:intl/intl.dart' as intl;
 abstract class PlutoColumnType {
   dynamic get defaultValue;
 
+  factory PlutoColumnType.custom({
+    dynamic defaultValue = '',
+  }) {
+    return PlutoColumnTypeCustom(
+      defaultValue: defaultValue,
+    );
+  }
+
   /// Set as a string column.
   factory PlutoColumnType.text({
     dynamic defaultValue = '',
@@ -173,6 +181,8 @@ extension PlutoColumnTypeExtension on PlutoColumnType {
   bool get isDate => this is PlutoColumnTypeDate;
 
   bool get isTime => this is PlutoColumnTypeTime;
+
+  bool get isCustom => this is PlutoColumnTypeCustom;
 
   PlutoColumnTypeText get text {
     if (this is! PlutoColumnTypeText) {
@@ -505,6 +515,30 @@ class PlutoColumnTypeTime
   @override
   dynamic makeCompareValue(dynamic v) {
     return v;
+  }
+}
+
+class PlutoColumnTypeCustom implements PlutoColumnType {
+  @override
+  final dynamic defaultValue;
+
+  const PlutoColumnTypeCustom({
+    this.defaultValue,
+  });
+
+  @override
+  bool isValid(dynamic value) {
+    return value is String || value is num;
+  }
+
+  @override
+  int compare(dynamic a, dynamic b) {
+    return _compareWithNull(a, b, () => a.toString().compareTo(b.toString()));
+  }
+
+  @override
+  dynamic makeCompareValue(dynamic v) {
+    return v.toString();
   }
 }
 

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -392,6 +392,19 @@ class _CellState extends PlutoStateWithChange<_Cell> {
           column: widget.column,
           row: widget.row,
         );
+      } else if (widget.column.type.isCustom) {
+        return widget.column.customCell?.call(
+              stateManager,
+              widget.cell,
+              widget.column,
+              widget.row,
+            ) ??
+            PlutoTextCell(
+              stateManager: stateManager,
+              cell: widget.cell,
+              column: widget.column,
+              row: widget.row,
+            );
       }
     }
 

--- a/test/src/ui/pluto_base_cell_test.dart
+++ b/test/src/ui/pluto_base_cell_test.dart
@@ -197,6 +197,94 @@ void main() {
   });
 
   testWidgets(
+      'WHEN If it is CurrentCell with custom type without custom cell'
+      'THEN [TextCellWidget] should be rendered', (WidgetTester tester) async {
+    // given
+    final PlutoCell cell = PlutoCell(value: 'cell value');
+
+    final PlutoColumn column = PlutoColumn(
+      title: 'header',
+      field: 'header',
+      type: PlutoColumnType.custom(),
+    );
+
+    final PlutoRow row = PlutoRow(
+      cells: {
+        'header': cell,
+      },
+    );
+
+    const rowIdx = 0;
+
+    // when
+    when(stateManager.isCurrentCell(any)).thenReturn(true);
+    when(stateManager.isEditing).thenReturn(true);
+
+    await tester.pumpWidget(
+      buildApp(
+        cell: cell,
+        column: column,
+        rowIdx: rowIdx,
+        row: row,
+      ),
+    );
+
+    // then
+    expect(find.text('cell value'), findsOneWidget);
+    expect(find.byType(PlutoSelectCell), findsNothing);
+    expect(find.byType(PlutoNumberCell), findsNothing);
+    expect(find.byType(PlutoDateCell), findsNothing);
+    expect(find.byType(PlutoTimeCell), findsNothing);
+    expect(find.byType(PlutoTextCell), findsOneWidget);
+  });
+
+  testWidgets(
+      'WHEN If it is CurrentCell with custom type and custom cell'
+      'THEN custom widget should be rendered', (WidgetTester tester) async {
+    // given
+    final PlutoCell cell = PlutoCell(value: 'cell value');
+
+    final PlutoColumn column = PlutoColumn(
+      title: 'header',
+      field: 'header',
+      type: PlutoColumnType.custom(),
+      customCell: (stateManager, cell, column, row) {
+        return const CircularProgressIndicator();
+      },
+    );
+
+    final PlutoRow row = PlutoRow(
+      cells: {
+        'header': cell,
+      },
+    );
+
+    const rowIdx = 0;
+
+    // when
+    when(stateManager.isCurrentCell(any)).thenReturn(true);
+    when(stateManager.isEditing).thenReturn(true);
+
+    await tester.pumpWidget(
+      buildApp(
+        cell: cell,
+        column: column,
+        rowIdx: rowIdx,
+        row: row,
+      ),
+    );
+
+    // then
+    expect(find.text('cell value'), findsNothing);
+    expect(find.byType(PlutoSelectCell), findsNothing);
+    expect(find.byType(PlutoNumberCell), findsNothing);
+    expect(find.byType(PlutoDateCell), findsNothing);
+    expect(find.byType(PlutoTimeCell), findsNothing);
+    expect(find.byType(PlutoTextCell), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets(
       'WHEN If it is CurrentCell and in Editing state'
       'THEN [TimeCellWidget] should be rendered', (WidgetTester tester) async {
     // given

--- a/test/src/ui/pluto_base_cell_test.dart
+++ b/test/src/ui/pluto_base_cell_test.dart
@@ -197,7 +197,7 @@ void main() {
   });
 
   testWidgets(
-      'WHEN If it is CurrentCell with custom type without custom cell'
+      'WHEN If it is CurrentCell with a custom type without custom cell'
       'THEN [TextCellWidget] should be rendered', (WidgetTester tester) async {
     // given
     final PlutoCell cell = PlutoCell(value: 'cell value');


### PR DESCRIPTION
## Description
This PR aims to enable custom cell creation.
To display the custom cell, you must create a `PlutoColumn` with the `custom` type and pass the desired widget to the `customCell` attribute, as in the example below:

```
final PlutoColumn column = PlutoColumn(
       title: 'header',
       field: 'header',
       type: PlutoColumnType.custom(),
       customCell: (stateManager, cell, column, row) {
         return const CircularProgressIndicator();
       },
     );
```