### PR TITLE
Add customization of shortcut events in the grid

### DIFF
--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -85,6 +85,7 @@ class PlutoGrid extends PlutoStatefulWidget {
     this.configuration = const PlutoGridConfiguration(),
     this.notifierFilterResolver,
     this.mode = PlutoGridMode.normal,
+    this.customShortcutEvent,
   }) : super(key: key);
 
   /// {@template pluto_grid_property_columns}
@@ -336,6 +337,8 @@ class PlutoGrid extends PlutoStatefulWidget {
   /// [PlutoGridMode.popup]
   /// {@macro pluto_grid_mode_popup}
   final PlutoGridMode mode;
+
+  final void Function(RawKeyEvent)? customShortcutEvent;
 
   /// [setDefaultLocale] sets locale when [Intl] package is used in [PlutoGrid].
   ///
@@ -610,6 +613,8 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
 
   KeyEventResult _handleGridFocusOnKey(FocusNode focusNode, RawKeyEvent event) {
     if (_keyManager.eventResult.isSkip == false) {
+      widget.customShortcutEvent?.call(event);
+
       _keyManager.subject.add(PlutoKeyManagerEvent(
         focusNode: focusNode,
         event: event,


### PR DESCRIPTION
## Description
This PR aims to add customization of shortcut events on the grid by implementing a new `customShortcutEvent` callback.

The `customShortcutEvent` callback will be called when the grid has focus and when **not** editing a cell.

### Usage
```dart
PlutoGrid(
  columns: columns,
  rows: rows,
  onLoaded: (PlutoGridOnLoadedEvent event) {
    stateManager = event.stateManager;
  },
  customShortcutEvent: (event) {
    if (event.isControlPressed && event.isKeyPressed(LogicalKeyboardKey.keyZ)) {
      print('UNDO');
    }
  },
)
```