### PR TITLE
Enabling to Lose Cell Focus

### DIFF
--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -63,6 +63,13 @@ mixin PopupCellState<T extends PopupCell> on State<T>
           widget.column.formattedValueForDisplayInEditing(widget.cell.value);
 
     textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
+
+    textFocus.addListener(() {
+      if (!textFocus.hasFocus) {
+        textController.text =
+            widget.column.formattedValueForDisplayInEditing(widget.cell.value);
+      }
+    });
   }
 
   @override

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -63,6 +63,12 @@ mixin PopupCellState<T extends PopupCell> on State<T>
           widget.column.formattedValueForDisplayInEditing(widget.cell.value);
 
     textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
+
+    textFocus.addListener(() {
+      if (!textFocus.hasFocus) {
+        handleSelected(textController.text);
+      }
+    });
   }
 
   @override

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -63,12 +63,6 @@ mixin PopupCellState<T extends PopupCell> on State<T>
           widget.column.formattedValueForDisplayInEditing(widget.cell.value);
 
     textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
-
-    textFocus.addListener(() {
-      if (!textFocus.hasFocus) {
-        handleSelected(textController.text);
-      }
-    });
   }
 
   @override

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -54,6 +54,12 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
 
     cellFocus = FocusNode(onKey: _handleOnKey);
 
+    cellFocus.addListener(() {
+      if (!cellFocus.hasFocus) {
+        _handleOnComplete();
+      }
+    });
+
     widget.stateManager.setTextEditingController(_textController);
 
     _textController.text = formattedValue;


### PR DESCRIPTION
## Descrition

This PR aims to make it possible to lose the focus of the cell, when this focus is requested in another location, saving the data typed in the cell

## Working

- Text field

[grid-2023-07-05_17.21.05.webm](https://github.com/oxeanbits/pluto_grid/assets/51444228/17d20793-52a4-46fc-9313-c2c719d3a7a3)

- Drop field

[gridData-2023-07-06_10.10.40.webm](https://github.com/oxeanbits/pluto_grid/assets/51444228/39222162-8ed2-40a8-bb09-bfc6577eb705)
