### PR TITLE
Feat: Unfocus cell when click out of the grid

### DIFF
--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -64,6 +64,13 @@ mixin PopupCellState<T extends PopupCell> on State<T>
 
     textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
 
+    textFocus.addListener(() {
+      if (!textFocus.hasFocus) {
+        textController.text =
+            widget.column.formattedValueForDisplayInEditing(widget.cell.value);
+      }
+    });
+
     textFocus.addListener(_handleFocusChange);
   }
 
@@ -79,9 +86,7 @@ mixin PopupCellState<T extends PopupCell> on State<T>
   }
 
   void _handleFocusChange() {
-    if (!textFocus.hasFocus) {
-      textController.text =
-          widget.column.formattedValueForDisplayInEditing(widget.cell.value);
+    if (!textFocus.hasFocus && !isOpenedPopup) {
       widget.stateManager.setEditing(false);
     }
   }

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -64,21 +64,26 @@ mixin PopupCellState<T extends PopupCell> on State<T>
 
     textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
 
-    textFocus.addListener(() {
-      if (!textFocus.hasFocus) {
-        textController.text =
-            widget.column.formattedValueForDisplayInEditing(widget.cell.value);
-      }
-    });
+    textFocus.addListener(_handleFocusChange);
   }
 
   @override
   void dispose() {
+    textFocus.removeListener(_handleFocusChange);
+
     textController.dispose();
 
     textFocus.dispose();
 
     super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (!textFocus.hasFocus) {
+      textController.text =
+          widget.column.formattedValueForDisplayInEditing(widget.cell.value);
+      widget.stateManager.setEditing(false);
+    }
   }
 
   void openPopup() {

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -54,11 +54,7 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
 
     cellFocus = FocusNode(onKey: _handleOnKey);
 
-    cellFocus.addListener(() {
-      if (!cellFocus.hasFocus) {
-        _handleOnComplete();
-      }
-    });
+    cellFocus.addListener(_handleFocusChange);
 
     widget.stateManager.setTextEditingController(_textController);
 
@@ -79,6 +75,8 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
      * Saves the changed value when moving a cell while text is being input.
      * if user do not press enter key, onEditingComplete is not called and the value is not saved.
      */
+    cellFocus.removeListener(_handleFocusChange);
+
     if (_cellEditingStatus.isChanged) {
       _changeValue();
     }
@@ -258,6 +256,13 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       textAlignVertical: TextAlignVertical.center,
       textAlign: widget.column.textAlign.value,
     );
+  }
+}
+
+void _handleFocusChange() {
+  if (!cellFocus.hasFocus) {
+    _handleOnComplete();
+    widget.stateManager.setEditing(false);
   }
 }
 

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -95,6 +95,13 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
     super.dispose();
   }
 
+  void _handleFocusChange() {
+    if (!cellFocus.hasFocus) {
+      _handleOnComplete();
+      widget.stateManager.setEditing(false);
+    }
+  }
+
   void _restoreText() {
     if (_cellEditingStatus.isNotChanged) {
       return;
@@ -256,13 +263,6 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       textAlignVertical: TextAlignVertical.center,
       textAlign: widget.column.textAlign.value,
     );
-  }
-}
-
-void _handleFocusChange() {
-  if (!cellFocus.hasFocus) {
-    _handleOnComplete();
-    widget.stateManager.setEditing(false);
   }
 }
 


### PR DESCRIPTION
## Description

This PR aims to remove the cell's editing mode when losing focus. Allowing to remove the focus from the cell when clicking outside the grid.

## Working

### Before

https://github.com/oxeanbits/pluto_grid/assets/14595398/f9459c49-89cf-4a0b-8152-ebfc6b58d41d

### After

https://github.com/oxeanbits/pluto_grid/assets/14595398/85c5cf51-7488-4154-9be9-b41e48e26c1d
