### PR TITLE
Enable receive custom popup dialog in ColumnMenuDelegate

### DIFF
--- a/demo/lib/screen/feature/column_menu_screen.dart
+++ b/demo/lib/screen/feature/column_menu_screen.dart
@@ -107,6 +107,16 @@ class _UserColumnMenu implements PlutoColumnMenuDelegate<_UserColumnMenuItem> {
         break;
     }
   }
+
+  @override
+  Future<_UserColumnMenuItem?>? showColumnMenu({
+    required BuildContext context,
+    required Offset position,
+    required List<Widget> items,
+    Color backgroundColor = Colors.white,
+  }) {
+    return Future.value(_UserColumnMenuItem.moveNext);
+  }
 }
 
 enum _UserColumnMenuItem {

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pluto_grid/pluto_grid.dart';
 
 abstract class PlutoColumnMenuDelegate<T> {
-  List<PopupMenuEntry<T>> buildMenuItems({
+  List<Widget> buildMenuItems({
     required PlutoGridStateManager stateManager,
     required PlutoColumn column,
   });
@@ -15,10 +15,10 @@ abstract class PlutoColumnMenuDelegate<T> {
     required T? selected,
   });
 
-  Future<T?>? showColumnMenu<T>({
+  Future<T?>? showColumnMenu({
     required BuildContext context,
     required Offset position,
-    required List<PopupMenuEntry<T>> items,
+    required List<Widget> items,
     Color backgroundColor = Colors.white,
   });
 }
@@ -28,14 +28,17 @@ class PlutoColumnMenuDelegateDefault
   const PlutoColumnMenuDelegateDefault();
 
   @override
-  Future<PlutoGridColumnMenuItem?>? showColumnMenu<PlutoGridColumnMenuItem>({
+  Future<PlutoGridColumnMenuItem?>? showColumnMenu({
     required BuildContext context,
     required Offset position,
-    required List<PopupMenuEntry<PlutoGridColumnMenuItem>> items,
+    required List<Widget> items,
     Color backgroundColor = Colors.white,
   }) {
     final RenderBox overlay =
         Overlay.of(context).context.findRenderObject() as RenderBox;
+
+    final List<PopupMenuEntry<PlutoGridColumnMenuItem>> finalItems =
+        items.cast<PopupMenuEntry<PlutoGridColumnMenuItem>>();
 
     return showMenu<PlutoGridColumnMenuItem>(
       context: context,
@@ -46,7 +49,7 @@ class PlutoColumnMenuDelegateDefault
         position.dx + overlay.size.width,
         position.dy + overlay.size.height,
       ),
-      items: items,
+      items: finalItems,
       useRootNavigator: true,
     );
   }
@@ -104,38 +107,6 @@ class PlutoColumnMenuDelegateDefault
     }
   }
 }
-
-// Open the context menu on the right side of the column.
-
-// Como sobreescrever esse método pra mostrar o widget que eu quero?
-
-// Como indicar o widget que eu quero de maneira não agressiva ao resto da aplicação?
-//  Talvez mudar e indicar na classe abstrata
-
-// Ele pode receber a lista de objetos mostráveis e ter outro método sobreescritivel capaz de selecionar qual vai ser, e como padrão seria esse aquis
-// @override
-// Future<PlutoGridColumnMenuItem?>? showColumnMenu<PlutoGridColumnMenuItem>({
-//   required BuildContext context,
-//   required Offset position,
-//   required List<PopupMenuEntry<PlutoGridColumnMenuItem>> items,
-//   Color backgroundColor = Colors.white,
-// }) {
-//   final RenderBox overlay =
-//       Overlay.of(context).context.findRenderObject() as RenderBox;
-
-//   return showMenu<PlutoGridColumnMenuItem>(
-//     context: context,
-//     color: backgroundColor,
-//     position: RelativeRect.fromLTRB(
-//       position.dx,
-//       position.dy,
-//       position.dx + overlay.size.width,
-//       position.dy + overlay.size.height,
-//     ),
-//     items: items,
-//     useRootNavigator: true,
-//   );
-// }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({
   required PlutoGridStateManager stateManager,

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pluto_grid/pluto_grid.dart';
 
 abstract class PlutoColumnMenuDelegate<T> {
-  List<Widget> buildMenuItems({
+  List<PopupMenuEntry<T>> buildMenuItems({
     required PlutoGridStateManager stateManager,
     required PlutoColumn column,
   });
@@ -18,7 +18,7 @@ abstract class PlutoColumnMenuDelegate<T> {
   Future<T?>? showColumnMenu({
     required BuildContext context,
     required Offset position,
-    required List<Widget> items,
+    required List<PopupMenuEntry> items,
     Color backgroundColor = Colors.white,
   });
 }

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -14,11 +14,42 @@ abstract class PlutoColumnMenuDelegate<T> {
     required bool mounted,
     required T? selected,
   });
+
+  Future<T?>? showColumnMenu<T>({
+    required BuildContext context,
+    required Offset position,
+    required List<PopupMenuEntry<T>> items,
+    Color backgroundColor = Colors.white,
+  });
 }
 
 class PlutoColumnMenuDelegateDefault
     implements PlutoColumnMenuDelegate<PlutoGridColumnMenuItem> {
   const PlutoColumnMenuDelegateDefault();
+
+  @override
+  Future<PlutoGridColumnMenuItem?>? showColumnMenu<PlutoGridColumnMenuItem>({
+    required BuildContext context,
+    required Offset position,
+    required List<PopupMenuEntry<PlutoGridColumnMenuItem>> items,
+    Color backgroundColor = Colors.white,
+  }) {
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox;
+
+    return showMenu<PlutoGridColumnMenuItem>(
+      context: context,
+      color: backgroundColor,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx + overlay.size.width,
+        position.dy + overlay.size.height,
+      ),
+      items: items,
+      useRootNavigator: true,
+    );
+  }
 
   @override
   List<PopupMenuEntry<PlutoGridColumnMenuItem>> buildMenuItems({
@@ -74,29 +105,37 @@ class PlutoColumnMenuDelegateDefault
   }
 }
 
-/// Open the context menu on the right side of the column.
-Future<T?>? showColumnMenu<T>({
-  required BuildContext context,
-  required Offset position,
-  required List<PopupMenuEntry<T>> items,
-  Color backgroundColor = Colors.white,
-}) {
-  final RenderBox overlay =
-      Overlay.of(context).context.findRenderObject() as RenderBox;
+// Open the context menu on the right side of the column.
 
-  return showMenu<T>(
-    context: context,
-    color: backgroundColor,
-    position: RelativeRect.fromLTRB(
-      position.dx,
-      position.dy,
-      position.dx + overlay.size.width,
-      position.dy + overlay.size.height,
-    ),
-    items: items,
-    useRootNavigator: true,
-  );
-}
+// Como sobreescrever esse método pra mostrar o widget que eu quero?
+
+// Como indicar o widget que eu quero de maneira não agressiva ao resto da aplicação?
+//  Talvez mudar e indicar na classe abstrata
+
+// Ele pode receber a lista de objetos mostráveis e ter outro método sobreescritivel capaz de selecionar qual vai ser, e como padrão seria esse aquis
+// @override
+// Future<PlutoGridColumnMenuItem?>? showColumnMenu<PlutoGridColumnMenuItem>({
+//   required BuildContext context,
+//   required Offset position,
+//   required List<PopupMenuEntry<PlutoGridColumnMenuItem>> items,
+//   Color backgroundColor = Colors.white,
+// }) {
+//   final RenderBox overlay =
+//       Overlay.of(context).context.findRenderObject() as RenderBox;
+
+//   return showMenu<PlutoGridColumnMenuItem>(
+//     context: context,
+//     color: backgroundColor,
+//     position: RelativeRect.fromLTRB(
+//       position.dx,
+//       position.dy,
+//       position.dx + overlay.size.width,
+//       position.dy + overlay.size.height,
+//     ),
+//     items: items,
+//     useRootNavigator: true,
+//   );
+// }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({
   required PlutoGridStateManager stateManager,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -69,13 +69,16 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   }
 
   void _showContextMenu(BuildContext context, Offset position) async {
+    List<PopupMenuEntry<dynamic>> items =
+        stateManager.columnMenuDelegate.buildMenuItems(
+      stateManager: stateManager,
+      column: widget.column,
+    );
+
     final selected = stateManager.columnMenuDelegate.showColumnMenu(
       context: context,
       position: position,
-      items: stateManager.columnMenuDelegate.buildMenuItems(
-        stateManager: stateManager,
-        column: widget.column,
-      ),
+      items: items,
     );
 
     // final selected = await showColumnMenu(

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -74,7 +74,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       column: widget.column,
     );
 
-    final selected = stateManager.columnMenuDelegate.showColumnMenu(
+    final selected = await stateManager.columnMenuDelegate.showColumnMenu(
       context: context,
       position: position,
       items: items,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -69,8 +69,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   }
 
   void _showContextMenu(BuildContext context, Offset position) async {
-    List<PopupMenuEntry<dynamic>> items =
-        stateManager.columnMenuDelegate.buildMenuItems(
+    List<Widget> items = stateManager.columnMenuDelegate.buildMenuItems(
       stateManager: stateManager,
       column: widget.column,
     );
@@ -80,16 +79,6 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       position: position,
       items: items,
     );
-
-    // final selected = await showColumnMenu(
-    //   context: context,
-    //   position: position,
-    //   backgroundColor: stateManager.style.menuBackgroundColor,
-    // items: stateManager.columnMenuDelegate.buildMenuItems(
-    //   stateManager: stateManager,
-    //   column: widget.column,
-    // ),
-    // );
 
     if (context.mounted) {
       stateManager.columnMenuDelegate.onSelected(

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -69,15 +69,24 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   }
 
   void _showContextMenu(BuildContext context, Offset position) async {
-    final selected = await showColumnMenu(
+    final selected = stateManager.columnMenuDelegate.showColumnMenu(
       context: context,
       position: position,
-      backgroundColor: stateManager.style.menuBackgroundColor,
       items: stateManager.columnMenuDelegate.buildMenuItems(
         stateManager: stateManager,
         column: widget.column,
       ),
     );
+
+    // final selected = await showColumnMenu(
+    //   context: context,
+    //   position: position,
+    //   backgroundColor: stateManager.style.menuBackgroundColor,
+    // items: stateManager.columnMenuDelegate.buildMenuItems(
+    //   stateManager: stateManager,
+    //   column: widget.column,
+    // ),
+    // );
 
     if (context.mounted) {
       stateManager.columnMenuDelegate.onSelected(
@@ -190,6 +199,8 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 
 class PlutoGridColumnIcon extends StatelessWidget {
   final PlutoColumnSort? sort;
+
+  // colocar icon de filter aqui?
 
   final Color color;
 

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -192,8 +192,6 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 class PlutoGridColumnIcon extends StatelessWidget {
   final PlutoColumnSort? sort;
 
-  // colocar icon de filter aqui?
-
   final Color color;
 
   final IconData icon;

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -69,7 +69,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   }
 
   void _showContextMenu(BuildContext context, Offset position) async {
-    List<Widget> items = stateManager.columnMenuDelegate.buildMenuItems(
+    List<PopupMenuEntry> items = stateManager.columnMenuDelegate.buildMenuItems(
       stateManager: stateManager,
       column: widget.column,
     );

--- a/test/src/pluto_grid_popup_test.dart
+++ b/test/src/pluto_grid_popup_test.dart
@@ -726,7 +726,7 @@ void main() {
 
 class _TestColumnMenu implements PlutoColumnMenuDelegate {
   @override
-  List<PopupMenuEntry> buildMenuItems({
+  List<PopupMenuEntry<String>> buildMenuItems({
     required PlutoGridStateManager stateManager,
     required PlutoColumn column,
   }) {
@@ -754,4 +754,31 @@ class _TestColumnMenu implements PlutoColumnMenuDelegate {
     required bool mounted,
     required selected,
   }) {}
+
+  @override
+  Future<String?>? showColumnMenu({
+    required BuildContext context,
+    required Offset position,
+    required List<Widget> items,
+    Color backgroundColor = Colors.white,
+  }) {
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox;
+
+    final List<PopupMenuEntry<String>> finalItems =
+        items.cast<PopupMenuEntry<String>>();
+
+    return showMenu<String>(
+      context: context,
+      color: backgroundColor,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx + overlay.size.width,
+        position.dy + overlay.size.height,
+      ),
+      items: finalItems,
+      useRootNavigator: true,
+    );
+  }
 }


### PR DESCRIPTION
## Description

This PR aims to allow the `ColumnMenuDelegate`, the delegate that controls the popup when the 3 points are pressed, to receive a custom dialog. Before this PR was only possible to override the default class to pass a list of `PopupMenuEntry`, an abstract class that contains a child widget and a value to be returned, passed to `showMenu` dialog. It wasn't possible to create any other type of dialog.

Now, it's possible to override the method resposible to call the popup, `showColumnMenu`, passing a custom dialog.

Important to add it's necessary to override and in the callback of the action, pass the value on the `Navigator.pop(context, returned_value)`, this value will be received by `onSelected` method.

## Main points

### Before

Example created looking the `PlutoColumnMenuDelegateDefault`.

The method `_getDefaultColumnMenuItems` create a list of `PopupMenuEntry` widget.
It's obligatory to pass `PopupMenuEntry`, because the method `showColumnMenu`, call the `showMenu` dialog, and it's called in the `PlutoColumnTitle`, which it's not possible to edit or override in any way.

```
@override
List<PopupMenuEntry<PlutoGridColumnMenuItem>> buildMenuItems({
  required PlutoGridStateManager stateManager,
  required PlutoColumn column,
}) {
  return _getDefaultColumnMenuItems(
    stateManager: stateManager,
    column: column,
  );
}
```

```
final selected = await showColumnMenu(
  context: context,
  position: position,
  backgroundColor: stateManager.style.menuBackgroundColor,
  items: stateManager.columnMenuDelegate.buildMenuItems(
    stateManager: stateManager,
    column: widget.column,
  ),
);
```

### Now

Now, the `showColumnMenu` method it's declared in `PlutoColumnMenuDelegate` abstract class. So it's possible to implement to a new class, and create a new dialog. And this method must receive all the options passing in `buildMenuItems`, but can return any type.

## How to smoke

- If you want to continue in the default, it will be necessary to override the `showColumnMenu` like the default:

 ```
@override
Future<PlutoGridColumnMenuItem?>? showColumnMenu({
  required BuildContext context,
  required Offset position,
  required List<Widget> items,
  Color backgroundColor = Colors.white,
}) {
  final RenderBox overlay =
      Overlay.of(context).context.findRenderObject() as RenderBox;

  final List<PopupMenuEntry<PlutoGridColumnMenuItem>> finalItems =
      items.cast<PopupMenuEntry<PlutoGridColumnMenuItem>>();

  return showMenu<PlutoGridColumnMenuItem>(
    context: context,
    color: backgroundColor,
    position: RelativeRect.fromLTRB(
      position.dx,
      position.dy,
      position.dx + overlay.size.width,
      position.dy + overlay.size.height,
    ),
    items: finalItems,
    useRootNavigator: true,
  );
}
```

- You can create a custom dialog PlutoColumnMenuDelegate, such as the bellow.

```
import 'package:flutter/material.dart';
import 'package:pluto_grid/pluto_grid.dart';

enum PlutoGridColumnMenuItem {
  unfreeze,
  freezeToStart,
  freezeToEnd,
  hideColumn,
  setColumns,
  autoFit,
  setFilter,
  resetFilter,
}

class GridColumnMenu
    implements PlutoColumnMenuDelegate<PlutoGridColumnMenuItem> {
  final BuildContext context;

  GridColumnMenu(this.context);

  @override
  List<PopupMenuEntry<PlutoGridColumnMenuItem>> buildMenuItems({
    required PlutoGridStateManager stateManager,
    required PlutoColumn column,
  }) {
    return const [
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.unfreeze,
        enabled: true,
        child: Text(
          'Unfreeze',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.freezeToStart,
        enabled: true,
        child: Text(
          'Freeze To Start',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.freezeToEnd,
        enabled: true,
        child: Text(
          'Freeze To End',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.hideColumn,
        enabled: true,
        child: Text(
          'Hide Column',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.setColumns,
        enabled: true,
        child: Text(
          'Set Columns',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.autoFit,
        enabled: true,
        child: Text(
          'Auto Fit',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.setFilter,
        enabled: true,
        child: Text(
          'Set Filter',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.resetFilter,
        enabled: true,
        child: Text(
          'Reset Filter',
          style: TextStyle(color: Colors.white),
        ),
      ),
    ];
  }

  @override
  Future<void> onSelected({
    required BuildContext context,
    required PlutoGridStateManager stateManager,
    required PlutoColumn column,
    required bool mounted,
    required PlutoGridColumnMenuItem? selected,
  }) async {
    print('You tap in ${selected.toString()}');
  }

  @override
  Future<PlutoGridColumnMenuItem?>? showColumnMenu({
    required BuildContext context,
    required Offset position,
    required List<Widget> items,
    Color backgroundColor = Colors.white,
  }) {
    if (items.isEmpty) return null;

    final List<PopupMenuItem<PlutoGridColumnMenuItem>> finalItems =
        items.cast<PopupMenuItem<PlutoGridColumnMenuItem>>();

    return showDialog(
      context: context,
      builder: (_) {
        return Center(
          child: Container(
            decoration: BoxDecoration(
              color: Colors.white,
              borderRadius: BorderRadius.circular(5),
            ),
            height: 330,
            width: 300,
            child: Column(children: itemsList(finalItems)),
          ),
        );
      },
    );
  }

  List<Widget> itemsList(List<PopupMenuItem<PlutoGridColumnMenuItem>> items) {
    List<Widget> itemsList = [];

    itemsList.add(const Padding(padding: EdgeInsets.symmetric(vertical: 5)));

    for (var item in items) {
      var child = item.child;
      if (child == null) continue;

      itemsList.add(
        GestureDetector(
          child: Container(
            decoration: BoxDecoration(
              color: Colors.blue,
              borderRadius: BorderRadius.circular(5),
            ),
            height: 30,
            width: 280,
            child: Center(child: child),
          ),
          onTap: () {
            Navigator.pop(context, item.value);
          },
        ),
      );

      itemsList.add(const Padding(padding: EdgeInsets.symmetric(vertical: 5)));
    }

    return itemsList;
  }
}
```

#### Smoke Running
https://github.com/oxeanbits/pluto_grid/assets/50436424/daabc39f-5431-4b74-8743-f71ea4a6342f




