### PR TITLE
Adds overlay to left frozen rows

### DIFF
--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -81,6 +81,8 @@ class PlutoGridStateChangeNotifier extends PlutoChangeNotifier
     this.rowColorCallback,
     this.rowBorderCallback,
     this.cellTextStyleCallback,
+    this.rowIndicatorCallback,
+    this.rowLeftFloatingWidgetCallback,
     this.createHeader,
     this.createFooter,
     PlutoColumnMenuDelegate? columnMenuDelegate,
@@ -149,6 +151,12 @@ class PlutoGridStateChangeNotifier extends PlutoChangeNotifier
 
   @override
   final PlutoCellTextStyleCallback? cellTextStyleCallback;
+
+  @override
+  final PlutoRowIndicatorCallback? rowIndicatorCallback;
+
+  @override
+  final PlutoRowLeftFloatingWidgetCallback? rowLeftFloatingWidgetCallback;
 
   @override
   final CreateHeaderCallBack? createHeader;
@@ -233,6 +241,8 @@ class PlutoGridStateManager extends PlutoGridStateChangeNotifier {
     super.rowColorCallback,
     super.rowBorderCallback,
     super.cellTextStyleCallback,
+    super.rowIndicatorCallback,
+    super.rowLeftFloatingWidgetCallback,
     super.createHeader,
     super.createFooter,
     super.columnMenuDelegate,

--- a/lib/src/manager/state/row_state.dart
+++ b/lib/src/manager/state/row_state.dart
@@ -45,6 +45,10 @@ abstract class IRowState {
 
   PlutoCellTextStyleCallback? get cellTextStyleCallback;
 
+  PlutoRowIndicatorCallback? get rowIndicatorCallback;
+
+  PlutoRowLeftFloatingWidgetCallback? get rowLeftFloatingWidgetCallback;
+
   int? getRowIdxByOffset(double offset);
 
   PlutoRow? getRowByIdx(int rowIdx);

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -44,13 +44,12 @@ typedef CreateFooterCallBack = Widget Function(
     PlutoGridStateManager stateManager);
 
 typedef PlutoCellTextStyleCallback = TextStyle Function(
-    PlutoCellTextStyleContext rowColorContext);
+    PlutoRowContext rowColorContext);
 
-typedef PlutoRowColorCallback = Color Function(
-    PlutoRowColorContext rowColorContext);
+typedef PlutoRowColorCallback = Color Function(PlutoRowContext rowColorContext);
 
 typedef PlutoRowBorderCallback = Border Function(
-    PlutoRowBorderContext rowBorderContext);
+    PlutoRowContext rowBorderContext);
 
 typedef PlutoRowIndicatorCallback = Widget? Function(
     PlutoRowContext rowContext);
@@ -1522,21 +1521,7 @@ class PlutoGridOnColumnsMovedEvent {
 
 /// Argument of [PlutoGrid.rowColumnCallback] callback
 /// to dynamically change the background color of a row.
-class PlutoRowColorContext {
-  final PlutoRow row;
-
-  final int rowIdx;
-
-  final PlutoGridStateManager stateManager;
-
-  const PlutoRowColorContext({
-    required this.row,
-    required this.rowIdx,
-    required this.stateManager,
-  });
-}
-
-class PlutoRowBorderContext {
+class PlutoRowContext {
   final PlutoRow row;
 
   final int rowIdx;
@@ -1545,39 +1530,11 @@ class PlutoRowBorderContext {
 
   final bool isLeftFrozen;
 
-  const PlutoRowBorderContext({
-    required this.row,
-    required this.rowIdx,
-    required this.stateManager,
-    required this.isLeftFrozen,
-  });
-}
-
-class PlutoCellTextStyleContext {
-  final PlutoRow row;
-
-  final int rowIdx;
-
-  final PlutoGridStateManager stateManager;
-
-  const PlutoCellTextStyleContext({
-    required this.row,
-    required this.rowIdx,
-    required this.stateManager,
-  });
-}
-
-class PlutoRowContext {
-  final PlutoRow row;
-
-  final int rowIdx;
-
-  final PlutoGridStateManager stateManager;
-
   const PlutoRowContext({
     required this.row,
     required this.rowIdx,
     required this.stateManager,
+    this.isLeftFrozen = false,
   });
 }
 

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -52,6 +52,12 @@ typedef PlutoRowColorCallback = Color Function(
 typedef PlutoRowBorderCallback = Border Function(
     PlutoRowBorderContext rowBorderContext);
 
+typedef PlutoRowIndicatorCallback = Widget? Function(
+    PlutoRowContext rowContext);
+
+typedef PlutoRowLeftFloatingWidgetCallback = Widget? Function(
+    PlutoRowContext rowContext);
+
 /// [PlutoGrid] is a widget that receives columns and rows and is expressed as a grid-type UI.
 ///
 /// [PlutoGrid] supports movement and editing with the keyboard,
@@ -81,6 +87,8 @@ class PlutoGrid extends PlutoStatefulWidget {
     this.rowColorCallback,
     this.rowBorderCallback,
     this.cellTextStyleCallback,
+    this.rowIndicatorCallback,
+    this.rowLeftFloatingWidgetCallback,
     this.columnMenuDelegate,
     this.configuration = const PlutoGridConfiguration(),
     this.notifierFilterResolver,
@@ -304,6 +312,10 @@ class PlutoGrid extends PlutoStatefulWidget {
   final PlutoRowBorderCallback? rowBorderCallback;
 
   final PlutoCellTextStyleCallback? cellTextStyleCallback;
+
+  final PlutoRowIndicatorCallback? rowIndicatorCallback;
+
+  final PlutoRowLeftFloatingWidgetCallback? rowLeftFloatingWidgetCallback;
 
   /// {@template pluto_grid_property_columnMenuDelegate}
   /// Column menu can be customized.
@@ -533,6 +545,8 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
       rowColorCallback: widget.rowColorCallback,
       rowBorderCallback: widget.rowBorderCallback,
       cellTextStyleCallback: widget.cellTextStyleCallback,
+      rowIndicatorCallback: widget.rowIndicatorCallback,
+      rowLeftFloatingWidgetCallback: widget.rowLeftFloatingWidgetCallback,
       createHeader: widget.createHeader,
       createFooter: widget.createFooter,
       columnMenuDelegate: widget.columnMenuDelegate,
@@ -1547,6 +1561,20 @@ class PlutoCellTextStyleContext {
   final PlutoGridStateManager stateManager;
 
   const PlutoCellTextStyleContext({
+    required this.row,
+    required this.rowIdx,
+    required this.stateManager,
+  });
+}
+
+class PlutoRowContext {
+  final PlutoRow row;
+
+  final int rowIdx;
+
+  final PlutoGridStateManager stateManager;
+
+  const PlutoRowContext({
     required this.row,
     required this.rowIdx,
     required this.stateManager,

--- a/lib/src/ui/cells/pluto_default_cell.dart
+++ b/lib/src/ui/cells/pluto_default_cell.dart
@@ -472,7 +472,7 @@ class _DefaultCellWidget extends StatelessWidget {
     );
 
     TextStyle cellTextStyle = stateManager.cellTextStyleCallback?.call(
-          PlutoCellTextStyleContext(
+          PlutoRowContext(
             rowIdx: rowIdx,
             row: row,
             stateManager: stateManager,

--- a/lib/src/ui/pluto_base_row.dart
+++ b/lib/src/ui/pluto_base_row.dart
@@ -246,7 +246,7 @@ class _RowContainerWidgetState extends PlutoStateWithChange<_RowContainerWidget>
     }
 
     return stateManager.rowColorCallback!(
-      PlutoRowColorContext(
+      PlutoRowContext(
         rowIdx: widget.rowIdx,
         row: widget.row,
         stateManager: stateManager,
@@ -286,7 +286,7 @@ class _RowContainerWidgetState extends PlutoStateWithChange<_RowContainerWidget>
     }
 
     return stateManager.rowBorderCallback!(
-      PlutoRowBorderContext(
+      PlutoRowContext(
         rowIdx: widget.rowIdx,
         row: widget.row,
         stateManager: stateManager,

--- a/test/src/ui/pluto_left_frozen_row_test.dart
+++ b/test/src/ui/pluto_left_frozen_row_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:pluto_grid/pluto_grid.dart';
+import 'package:pluto_grid/src/ui/ui.dart';
+import 'package:rxdart/rxdart.dart';
+
+import '../../helper/column_helper.dart';
+import '../../helper/pluto_widget_test_helper.dart';
+import '../../helper/row_helper.dart';
+import '../../mock/shared_mocks.mocks.dart';
+
+void main() {
+  late MockPlutoGridStateManager stateManager;
+  PublishSubject<PlutoNotifierEvent> streamNotifier;
+  List<PlutoColumn> columns;
+  List<PlutoRow> rows;
+  final resizingNotifier = ChangeNotifier();
+
+  setUp(() {
+    const configuration = PlutoGridConfiguration();
+    stateManager = MockPlutoGridStateManager();
+    streamNotifier = PublishSubject<PlutoNotifierEvent>();
+    when(stateManager.streamNotifier).thenAnswer((_) => streamNotifier);
+    when(stateManager.resizingChangeNotifier).thenReturn(resizingNotifier);
+    when(stateManager.configuration).thenReturn(configuration);
+    when(stateManager.style).thenReturn(configuration.style);
+    when(stateManager.localeText).thenReturn(const PlutoGridLocaleText());
+    when(stateManager.rowHeight).thenReturn(45);
+    when(stateManager.isSelecting).thenReturn(true);
+    when(stateManager.hasCurrentSelectingPosition).thenReturn(true);
+    when(stateManager.isEditing).thenReturn(true);
+    when(stateManager.selectingMode).thenReturn(PlutoGridSelectingMode.cell);
+    when(stateManager.hasFocus).thenReturn(true);
+    when(stateManager.canRowDrag).thenReturn(true);
+    when(stateManager.showFrozenColumn).thenReturn(false);
+    when(stateManager.enabledRowGroups).thenReturn(false);
+    when(stateManager.rowGroupDelegate).thenReturn(null);
+  });
+
+  buildRowWidget({
+    int rowIdx = 0,
+    PlutoRowIndicatorCallback? rowIndicatorCallback,
+    PlutoRowLeftFloatingWidgetCallback? leftFloatingCallback,
+  }) {
+    return PlutoWidgetTestHelper(
+      'build row widget.',
+      (tester) async {
+        if (rowIndicatorCallback != null) {
+          when(stateManager.rowIndicatorCallback)
+              .thenAnswer((_) => rowIndicatorCallback);
+        }
+        if (leftFloatingCallback != null) {
+          when(stateManager.rowLeftFloatingWidgetCallback)
+              .thenAnswer((_) => leftFloatingCallback);
+        }
+
+        columns = ColumnHelper.textColumn('header', count: 3);
+        rows = RowHelper.count(10, columns);
+
+        when(stateManager.columns).thenReturn(columns);
+
+        final row = rows[rowIdx];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: FrozenRow(
+                rowIdx: rowIdx,
+                row: row,
+                columns: columns,
+                stateManager: stateManager,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  buildRowWidget(
+    leftFloatingCallback: (_) => Container(
+      color: Colors.yellow,
+    ),
+  ).test(
+    'rowLeftFloatingWidgetCallback defined',
+    (tester) async {
+      final rowFloatingWidget =
+          find.byType(Container).last.evaluate().last.widget as Container;
+
+      expect(
+        rowFloatingWidget.color,
+        Colors.yellow,
+      );
+    },
+  );
+
+  buildRowWidget(
+    rowIndicatorCallback: (_) => Container(
+      color: Colors.red,
+    ),
+  ).test(
+    'rowIndicatorCallback defined',
+    (tester) async {
+      final rowIndicatorWidget =
+          find.byType(Container).first.evaluate().first.widget as Container;
+
+      expect(
+        rowIndicatorWidget.color,
+        Colors.red,
+      );
+    },
+  );
+}


### PR DESCRIPTION
# Description

This PR adds the following attributes to the PlutoGrid widget.

- `rowIndicatorCallback`: It makes possible to pass a callback to define a widget over each left frozen row. The widget is constrained inside the grid borders.
- `rowLeftFloatingWidgetCallback`: It makes possible to pass a callback to define a widget over each left frozen row. The widget is added to the app overlay.

# How to use the modification

If `rowIndicatorCallback` is defined, a left frozen row will call it and add the returned widget to its Stack component.

```dart
PlutoGrid(
...
  rowIndicatorCallback: rowIndicatorHandler,
...
);

Widget? rowIndicatorHandler(PlutoRowContext rowContext) {
  bool rowHasError = getRowError(rowContext.row);
  return rowHasError ? Container(color: Colors.red, width: 2, height: 10) : null;
}
```

If `rowLeftFloatingWidgetCallback` is defined, a left frozen row will call it and add the returned widget to the app Overlay. The added widget will folow the row position as well.

```dart
PlutoGrid(
...
  rowLeftFloatingWidgetCallback: rowLeftFloatingHandler,
...
);

Widget? rowLeftFloatingHandler(PlutoRowContext rowContext) {
  bool rowHasError = getRowError(rowContext.row);
  if (!rowHasError) return null;
  return Transform.translate(
      offset: Offset(-30, 10),
      child: Container(color: Colors.red, width: 2, height: 10),
    );
}
```