### PR TITLE
Add leadingIcon widget beside PlutoColumnTitle icon

### DIFF
--- a/demo/lib/screen/feature/column_menu_screen.dart
+++ b/demo/lib/screen/feature/column_menu_screen.dart
@@ -119,7 +119,7 @@ class _UserColumnMenu implements PlutoColumnMenuDelegate<_UserColumnMenuItem> {
   }
 
   @override
-  Widget? auxiliarWidgetIndicator(PlutoColumn column) => null;
+  Widget? leadingIcon(PlutoColumn column) => null;
 }
 
 enum _UserColumnMenuItem {

--- a/demo/lib/screen/feature/column_menu_screen.dart
+++ b/demo/lib/screen/feature/column_menu_screen.dart
@@ -117,6 +117,9 @@ class _UserColumnMenu implements PlutoColumnMenuDelegate<_UserColumnMenuItem> {
   }) {
     return Future.value(_UserColumnMenuItem.moveNext);
   }
+
+  @override
+  Widget? auxiliarWidgetIndicator(PlutoColumn column) => null;
 }
 
 enum _UserColumnMenuItem {

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -21,6 +21,8 @@ abstract class PlutoColumnMenuDelegate<T> {
     required List<PopupMenuEntry> items,
     Color backgroundColor = Colors.white,
   });
+
+  Widget? auxiliarIconIndicator(PlutoColumn column);
 }
 
 class PlutoColumnMenuDelegateDefault
@@ -106,6 +108,9 @@ class PlutoColumnMenuDelegateDefault
         break;
     }
   }
+
+  @override
+  Widget? auxiliarIconIndicator(PlutoColumn column) => null;
 }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -22,7 +22,7 @@ abstract class PlutoColumnMenuDelegate<T> {
     Color backgroundColor = Colors.white,
   });
 
-  Widget? auxiliarWidgetIndicator(PlutoColumn column);
+  Widget? leadingIcon(PlutoColumn column);
 }
 
 class PlutoColumnMenuDelegateDefault
@@ -110,7 +110,7 @@ class PlutoColumnMenuDelegateDefault
   }
 
   @override
-  Widget? auxiliarWidgetIndicator(PlutoColumn column) => null;
+  Widget? leadingIcon(PlutoColumn column) => null;
 }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -22,7 +22,7 @@ abstract class PlutoColumnMenuDelegate<T> {
     Color backgroundColor = Colors.white,
   });
 
-  Widget? auxiliarIconIndicator(PlutoColumn column);
+  Widget? auxiliarWidgetIndicator(PlutoColumn column);
 }
 
 class PlutoColumnMenuDelegateDefault
@@ -110,7 +110,7 @@ class PlutoColumnMenuDelegateDefault
   }
 
   @override
-  Widget? auxiliarIconIndicator(PlutoColumn column) => null;
+  Widget? auxiliarWidgetIndicator(PlutoColumn column) => null;
 }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -123,10 +123,33 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     _isPointMoving = false;
   }
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _titleIcons() {
     final style = stateManager.configuration.style;
 
+    return Row(
+      children: [
+        stateManager.columnMenuDelegate.auxiliarIconIndicator(widget.column) ??
+            Container(),
+        IconButton(
+          icon: PlutoGridColumnIcon(
+            sort: _sort,
+            color: style.iconColor,
+            icon: widget.column.enableContextMenu
+                ? style.columnContextIcon
+                : style.columnResizeIcon,
+            ascendingIcon: style.columnAscendingIcon,
+            descendingIcon: style.columnDescendingIcon,
+          ),
+          iconSize: style.iconSize,
+          mouseCursor: contextMenuCursor,
+          onPressed: null,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final columnWidget = _SortableWidget(
       stateManager: stateManager,
       column: widget.column,
@@ -141,20 +164,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       height: widget.height,
       child: Align(
         alignment: Alignment.center,
-        child: IconButton(
-          icon: PlutoGridColumnIcon(
-            sort: _sort,
-            color: style.iconColor,
-            icon: widget.column.enableContextMenu
-                ? style.columnContextIcon
-                : style.columnResizeIcon,
-            ascendingIcon: style.columnAscendingIcon,
-            descendingIcon: style.columnDescendingIcon,
-          ),
-          iconSize: style.iconSize,
-          mouseCursor: contextMenuCursor,
-          onPressed: null,
-        ),
+        child: _titleIcons(),
       ),
     );
 

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -128,7 +128,9 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 
     return Row(
       children: [
-        stateManager.columnMenuDelegate.auxiliarIconIndicator(widget.column) ??
+        stateManager.columnMenuDelegate.auxiliarWidgetIndicator(
+              widget.column,
+            ) ??
             Container(),
         IconButton(
           icon: PlutoGridColumnIcon(

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -129,8 +129,8 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     Widget? auxiliarIndicator;
 
     try {
-      auxiliarIndicator = stateManager.columnMenuDelegate
-          .auxiliarWidgetIndicator(widget.column);
+      auxiliarIndicator =
+          stateManager.columnMenuDelegate.leadingIcon(widget.column);
     } catch (e) {
       auxiliarIndicator = Container();
     }

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -126,12 +126,18 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   Widget _titleIcons() {
     final style = stateManager.configuration.style;
 
+    Widget? auxiliarIndicator;
+
+    try {
+      auxiliarIndicator = stateManager.columnMenuDelegate
+          .auxiliarWidgetIndicator(widget.column);
+    } catch (e) {
+      auxiliarIndicator = Container();
+    }
+
     return Row(
       children: [
-        stateManager.columnMenuDelegate.auxiliarWidgetIndicator(
-              widget.column,
-            ) ??
-            Container(),
+        auxiliarIndicator ?? Container(),
         IconButton(
           icon: PlutoGridColumnIcon(
             sort: _sort,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -126,18 +126,17 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   Widget _titleIcons() {
     final style = stateManager.configuration.style;
 
-    Widget? auxiliarIndicator;
+    Widget? leadingIcon;
 
     try {
-      auxiliarIndicator =
-          stateManager.columnMenuDelegate.leadingIcon(widget.column);
+      leadingIcon = stateManager.columnMenuDelegate.leadingIcon(widget.column);
     } catch (e) {
-      auxiliarIndicator = Container();
+      leadingIcon = Container();
     }
 
     return Row(
       children: [
-        auxiliarIndicator ?? Container(),
+        leadingIcon ?? Container(),
         IconButton(
           icon: PlutoGridColumnIcon(
             sort: _sort,
@@ -393,6 +392,15 @@ class _ColumnWidget extends StatelessWidget {
       builder: (dragContext, candidate, rejected) {
         final bool noDragTarget = candidate.isEmpty;
 
+        bool hasLeadingIcon = false;
+
+        try {
+          hasLeadingIcon =
+              stateManager.columnMenuDelegate.leadingIcon(column) != null;
+        } catch (e) {
+          hasLeadingIcon = false;
+        }
+
         final style = stateManager.style;
 
         return SizedBox(
@@ -410,7 +418,8 @@ class _ColumnWidget extends StatelessWidget {
                     : BorderSide.none,
               ),
             ),
-            child: Padding(
+            child: Container(
+              margin: hasLeadingIcon ? const EdgeInsets.only(right: 25) : null,
               padding: padding,
               child: Align(
                 alignment: Alignment.centerLeft,

--- a/test/src/pluto_grid_popup_test.dart
+++ b/test/src/pluto_grid_popup_test.dart
@@ -783,5 +783,5 @@ class _TestColumnMenu implements PlutoColumnMenuDelegate {
   }
 
   @override
-  Widget? auxiliarWidgetIndicator(_) => null;
+  Widget? leadingIcon(_) => null;
 }

--- a/test/src/pluto_grid_popup_test.dart
+++ b/test/src/pluto_grid_popup_test.dart
@@ -781,4 +781,7 @@ class _TestColumnMenu implements PlutoColumnMenuDelegate {
       useRootNavigator: true,
     );
   }
+
+  @override
+  Widget? auxiliarIconIndicator(_) => null;
 }

--- a/test/src/pluto_grid_popup_test.dart
+++ b/test/src/pluto_grid_popup_test.dart
@@ -783,5 +783,5 @@ class _TestColumnMenu implements PlutoColumnMenuDelegate {
   }
 
   @override
-  Widget? auxiliarIconIndicator(_) => null;
+  Widget? auxiliarWidgetIndicator(_) => null;
 }


### PR DESCRIPTION
## Description

This PR aims to allow to create an auxiliar widget beside PlutoColumnTitle icon, that can be passed by implementing the PlutoColumnMenuDelegate.

It can be used to add a verification if the column is filter, to remove the filter, etc.

This can be controlled by adding a conditional statement using the PlutoColumn received by the method to show only in the right column. Can controlled some type of state in the onSelected method too.

## How to smoke

- You can create such as the bellow.

```
import 'package:flutter/material.dart';
import 'package:pluto_grid/pluto_grid.dart';

enum PlutoGridColumnMenuItem {
  unfreeze,
  freezeToStart,
  freezeToEnd,
  hideColumn,
  setColumns,
  autoFit,
  setFilter,
  resetFilter,
}

class GridColumnMenu
    implements PlutoColumnMenuDelegate<PlutoGridColumnMenuItem> {
  final BuildContext context;

  GridColumnMenu(this.context);

  @override
  Widget? auxiliarWidgetIndicator(PlutoColumn column) {
    return Tooltip(
      child: const Icon(Icons.filter),
      message: "This is '${column.title}' column",
    );
  }

  @override
  List<PopupMenuEntry<PlutoGridColumnMenuItem>> buildMenuItems({
    required PlutoGridStateManager stateManager,
    required PlutoColumn column,
  }) {
    return const [
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.unfreeze,
        enabled: true,
        child: Text(
          'Unfreeze',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.freezeToStart,
        enabled: true,
        child: Text(
          'Freeze To Start',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.freezeToEnd,
        enabled: true,
        child: Text(
          'Freeze To End',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.hideColumn,
        enabled: true,
        child: Text(
          'Hide Column',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.setColumns,
        enabled: true,
        child: Text(
          'Set Columns',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.autoFit,
        enabled: true,
        child: Text(
          'Auto Fit',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.setFilter,
        enabled: true,
        child: Text(
          'Set Filter',
          style: TextStyle(color: Colors.white),
        ),
      ),
      PopupMenuItem<PlutoGridColumnMenuItem>(
        value: PlutoGridColumnMenuItem.resetFilter,
        enabled: true,
        child: Text(
          'Reset Filter',
          style: TextStyle(color: Colors.white),
        ),
      ),
    ];
  }

  @override
  Future<void> onSelected({
    required BuildContext context,
    required PlutoGridStateManager stateManager,
    required PlutoColumn column,
    required bool mounted,
    required PlutoGridColumnMenuItem? selected,
  }) async {
    print('You tap in ${selected.toString()}');
  }

  @override
  Future<PlutoGridColumnMenuItem?>? showColumnMenu({
    required BuildContext context,
    required Offset position,
    required List<Widget> items,
    Color backgroundColor = Colors.white,
  }) {
    if (items.isEmpty) return null;

    final List<PopupMenuItem<PlutoGridColumnMenuItem>> finalItems =
        items.cast<PopupMenuItem<PlutoGridColumnMenuItem>>();

    return showDialog(
      context: context,
      builder: (_) {
        return Center(
          child: Container(
            decoration: BoxDecoration(
              color: Colors.white,
              borderRadius: BorderRadius.circular(5),
            ),
            height: 330,
            width: 300,
            child: Column(children: itemsList(finalItems)),
          ),
        );
      },
    );
  }

  List<Widget> itemsList(List<PopupMenuItem<PlutoGridColumnMenuItem>> items) {
    List<Widget> itemsList = [];

    itemsList.add(const Padding(padding: EdgeInsets.symmetric(vertical: 5)));

    for (var item in items) {
      var child = item.child;
      if (child == null) continue;

      itemsList.add(
        GestureDetector(
          child: Container(
            decoration: BoxDecoration(
              color: Colors.blue,
              borderRadius: BorderRadius.circular(5),
            ),
            height: 30,
            width: 280,
            child: Center(child: child),
          ),
          onTap: () {
            Navigator.pop(context, item.value);
          },
        ),
      );

      itemsList.add(const Padding(padding: EdgeInsets.symmetric(vertical: 5)));
    }

    return itemsList;
  }
}
```

## Smoke Running
![image](https://github.com/oxeanbits/pluto_grid/assets/50436424/eaef2085-2520-4ea1-823d-a94c2896ba1d)

