### PR TITLE
Updates titleSpan to receive a callback

### DIFF
--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -61,7 +61,7 @@ class PlutoColumn {
   ///   ],
   /// ),
   /// ```
-  InlineSpan? titleSpan;
+  InlineSpan Function(PlutoColumnContext context)? titleSpan;
 
   /// Customisable cell padding.
   /// It takes precedence over defaultCellPadding in PlutoGridConfiguration.

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1538,6 +1538,17 @@ class PlutoRowContext {
   });
 }
 
+class PlutoColumnContext {
+  final PlutoColumn column;
+
+  final PlutoGridStateManager stateManager;
+
+  const PlutoColumnContext({
+    required this.column,
+    required this.stateManager,
+  });
+}
+
 /// Extension class for [ScrollConfiguration.behavior] of [PlutoGrid].
 class PlutoScrollBehavior extends MaterialScrollBehavior {
   const PlutoScrollBehavior({

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -565,7 +565,13 @@ class _ColumnTextWidgetState extends PlutoStateWithChange<_ColumnTextWidget> {
       widget.column.titleSpan == null ? widget.column.title : null;
 
   List<InlineSpan> get _children => [
-        if (widget.column.titleSpan != null) widget.column.titleSpan!,
+        if (widget.column.titleSpan != null)
+          widget.column.titleSpan!(
+            PlutoColumnContext(
+              column: widget.column,
+              stateManager: stateManager,
+            ),
+          ),
         if (_isFilteredList)
           WidgetSpan(
             alignment: PlaceholderAlignment.middle,


### PR DESCRIPTION
# Description

This PR changes the `titleSpan` property on PlutoColumn to receive a callback that has as argument PlutoColumnContext.

# How to use the modification

If `titleSpan` callback is defined, the column title is **replaced** by the InlineSpan widget returned from the callback.

```dart
PlutoColumn(
...
  titleSpan: (columnContext) => TextSpan(text: 'text'),
...
);
```