### PR TITLE
Fix Show icons and Mouse Cursor of Column Title

### DIFF
--- a/demo/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/demo/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,1 +1,1 @@
-C:/Users/manek/AppData/Local/Pub/Cache/hosted/pub.dev/url_launcher_linux-3.0.2/
+/home/anderson/.pub-cache/hosted/pub.dev/url_launcher_linux-3.0.6/

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -131,26 +131,34 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     try {
       leadingIcon = stateManager.columnMenuDelegate.leadingIcon(widget.column);
     } catch (e) {
-      leadingIcon = Container();
+      leadingIcon = null;
     }
+
+    Widget icon = leadingIcon ??
+        PlutoGridColumnIcon(
+          sort: _sort,
+          color: style.iconColor,
+          icon: widget.column.enableContextMenu
+              ? style.columnContextIcon
+              : style.columnResizeIcon,
+          ascendingIcon: style.columnAscendingIcon,
+          descendingIcon: style.columnDescendingIcon,
+        );
+
+    Widget iconButton = IconButton(
+      icon: icon,
+      iconSize: style.iconSize,
+      mouseCursor: SystemMouseCursors.basic,
+      onPressed: null,
+    );
 
     return Row(
       children: [
-        leadingIcon ?? Container(),
-        IconButton(
-          icon: PlutoGridColumnIcon(
-            sort: _sort,
-            color: style.iconColor,
-            icon: widget.column.enableContextMenu
-                ? style.columnContextIcon
-                : style.columnResizeIcon,
-            ascendingIcon: style.columnAscendingIcon,
-            descendingIcon: style.columnDescendingIcon,
-          ),
-          iconSize: style.iconSize,
-          mouseCursor: contextMenuCursor,
-          onPressed: null,
-        ),
+        iconButton,
+        MouseRegion(
+          cursor: contextMenuCursor,
+          child: Container(width: 10),
+        )
       ],
     );
   }

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -131,19 +131,18 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     try {
       leadingIcon = stateManager.columnMenuDelegate.leadingIcon(widget.column);
     } catch (e) {
-      leadingIcon = null;
+      leadingIcon;
     }
 
-    Widget icon = leadingIcon ??
-        PlutoGridColumnIcon(
-          sort: _sort,
-          color: style.iconColor,
-          icon: widget.column.enableContextMenu
-              ? style.columnContextIcon
-              : style.columnResizeIcon,
-          ascendingIcon: style.columnAscendingIcon,
-          descendingIcon: style.columnDescendingIcon,
-        );
+    Widget icon = PlutoGridColumnIcon(
+      sort: _sort,
+      color: style.iconColor,
+      icon: widget.column.enableContextMenu
+          ? style.columnContextIcon
+          : style.columnResizeIcon,
+      ascendingIcon: style.columnAscendingIcon,
+      descendingIcon: style.columnDescendingIcon,
+    );
 
     Widget iconButton = IconButton(
       icon: icon,
@@ -154,6 +153,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 
     return Row(
       children: [
+        leadingIcon ?? Container(),
         iconButton,
         MouseRegion(
           cursor: contextMenuCursor,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -147,7 +147,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     Widget iconButton = IconButton(
       icon: icon,
       iconSize: style.iconSize,
-      mouseCursor: SystemMouseCursors.basic,
+      mouseCursor: SystemMouseCursors.click,
       onPressed: null,
     );
 

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -153,7 +153,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 
     Widget dragging = MouseRegion(
       cursor: contextMenuCursor,
-      hitTestBehavior: HitTestBehavior.opaque,
+      hitTestBehavior: HitTestBehavior.translucent,
       child: Container(width: 5),
     );
 
@@ -208,6 +208,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
                     onPointerDown: _handleOnPointDown,
                     onPointerMove: _handleOnPointMove,
                     onPointerUp: _handleOnPointUp,
+                    behavior: HitTestBehavior.translucent,
                     child: contextMenuIcon,
                   )
                 : contextMenuIcon,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -151,14 +151,17 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       onPressed: null,
     );
 
+    Widget dragging = MouseRegion(
+      cursor: contextMenuCursor,
+      hitTestBehavior: HitTestBehavior.opaque,
+      child: Container(width: 5),
+    );
+
     return Row(
       children: [
         leadingIcon ?? Container(),
         iconButton,
-        MouseRegion(
-          cursor: contextMenuCursor,
-          child: Container(width: 10),
-        )
+        dragging,
       ],
     );
   }

--- a/packages/pluto_grid_export/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/pluto_grid_export/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import file_saver
-import path_provider_macos
+import path_provider_foundation
 import printing
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {


### PR DESCRIPTION
## Description:
This PR aims to apply fix on show icons of column title, and show basic mouseCursor if mouse is over the icon.

## Evidence

```
    Widget iconButton = IconButton(
      icon: icon,
      iconSize: style.iconSize,
      mouseCursor: SystemMouseCursors.click,
      onPressed: null,
    );

```

## Video (⚠️  remove before merging)

[Gravação de tela de 20-09-2023 09:28:20.webm](https://github.com/oxeanbits/pluto_grid/assets/51444228/a8745407-6acc-4066-8b9f-3b8c86c523d3)

