### PR TITLE
Fix hover icon of Column Title

### DIFF
--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -128,6 +128,9 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   Widget _titleIcons() {
     final style = stateManager.configuration.style;
 
+    bool isViewNormal =
+        stateManager.configuration.style.columnIconViewType.isNormal;
+
     Widget? leadingIcon;
 
     try {
@@ -136,20 +139,26 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       leadingIcon;
     }
 
+    Widget sortIcon = Visibility(
+      visible: _isHoveringIcon || isViewNormal || isSortingIcon(),
+      child: PlutoGridColumnSortIcon(
+        sort: _sort,
+        ascendingIcon: style.columnAscendingIcon,
+        descendingIcon: style.columnDescendingIcon,
+      ),
+    );
+
     Widget icon = PlutoGridColumnIcon(
-      sort: _sort,
       color: style.iconColor,
       icon: widget.column.enableContextMenu
           ? style.columnContextIcon
           : style.columnResizeIcon,
-      ascendingIcon: style.columnAscendingIcon,
-      descendingIcon: style.columnDescendingIcon,
     );
 
     Widget iconButton = Visibility(
-      visible: isSortingIcon() || leadingIcon == null,
+      visible: _isHoveringIcon || isViewNormal || leadingIcon != null,
       child: IconButton(
-        icon: icon,
+        icon: leadingIcon ?? icon,
         iconSize: style.iconSize,
         mouseCursor: SystemMouseCursors.click,
         onPressed: null,
@@ -162,20 +171,12 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       child: Container(width: 5),
     );
 
-    bool isViewNormal =
-        stateManager.configuration.style.columnIconViewType.isNormal;
-
-    bool alwaysShow = isViewNormal || isSortingIcon() || leadingIcon != null;
-
-    return Visibility(
-      visible: _isHoveringIcon || alwaysShow,
-      child: Row(
-        children: [
-          leadingIcon ?? Container(),
-          iconButton,
-          dragging,
-        ],
-      ),
+    return Row(
+      children: [
+        iconButton,
+        sortIcon,
+        dragging,
+      ],
     );
   }
 
@@ -271,20 +272,31 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
 }
 
 class PlutoGridColumnIcon extends StatelessWidget {
-  final PlutoColumnSort? sort;
-
   final Color color;
 
   final IconData icon;
+
+  const PlutoGridColumnIcon({
+    this.color = Colors.black26,
+    this.icon = Icons.dehaze,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(icon, color: color);
+  }
+}
+
+class PlutoGridColumnSortIcon extends StatelessWidget {
+  final PlutoColumnSort? sort;
 
   final Icon? ascendingIcon;
 
   final Icon? descendingIcon;
 
-  const PlutoGridColumnIcon({
+  const PlutoGridColumnSortIcon({
     this.sort,
-    this.color = Colors.black26,
-    this.icon = Icons.dehaze,
     this.ascendingIcon,
     this.descendingIcon,
     Key? key,
@@ -292,6 +304,13 @@ class PlutoGridColumnIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return Visibility(
+      visible: sort != PlutoColumnSort.none,
+      child: getIcon(),
+    );
+  }
+
+  Widget getIcon() {
     switch (sort) {
       case PlutoColumnSort.ascending:
         return ascendingIcon == null
@@ -310,11 +329,9 @@ class PlutoGridColumnIcon extends StatelessWidget {
                 color: Colors.red,
               )
             : descendingIcon!;
+
       default:
-        return Icon(
-          icon,
-          color: color,
-        );
+        return Container();
     }
   }
 }

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -146,11 +146,14 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
       descendingIcon: style.columnDescendingIcon,
     );
 
-    Widget iconButton = IconButton(
-      icon: icon,
-      iconSize: style.iconSize,
-      mouseCursor: SystemMouseCursors.click,
-      onPressed: null,
+    Widget iconButton = Visibility(
+      visible: isSortingIcon() || leadingIcon == null,
+      child: IconButton(
+        icon: icon,
+        iconSize: style.iconSize,
+        mouseCursor: SystemMouseCursors.click,
+        onPressed: null,
+      ),
     );
 
     Widget dragging = MouseRegion(
@@ -162,7 +165,7 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
     bool isViewNormal =
         stateManager.configuration.style.columnIconViewType.isNormal;
 
-    bool alwaysShow = isViewNormal || isSortingIcon();
+    bool alwaysShow = isViewNormal || isSortingIcon() || leadingIcon != null;
 
     return Visibility(
       visible: _isHoveringIcon || alwaysShow,

--- a/test/src/ui/columns/pluto_column_title_test.dart
+++ b/test/src/ui/columns/pluto_column_title_test.dart
@@ -699,7 +699,7 @@ void main() {
       'If columnAscendingIcon is set, the set icon should appear.',
       (tester) async {
         final target = find.descendant(
-          of: find.byType(PlutoColumnTitle),
+          of: find.byType(PlutoGridColumnSortIcon),
           matching: find.byType(Icon),
         );
 
@@ -729,7 +729,7 @@ void main() {
       'If columnDescendingIcon is set, the set icon should appear.',
       (tester) async {
         final target = find.descendant(
-          of: find.byType(PlutoColumnTitle),
+          of: find.byType(PlutoGridColumnSortIcon),
           matching: find.byType(Icon),
         );
 


### PR DESCRIPTION
Problem: When filtering was applied, the icons were not visible to indicate that it was filtered.

Solution: is to check if the filtering icon exists, the main solution icon and the icon button only appear for sorting.


- now


[Gravação de tela de 27-03-2024 10:26:16.webm](https://github.com/oxeanbits/pluto_grid/assets/51444228/16f21789-9cb4-47e3-98ca-e66377bdb558)





- Master


[Gravação de tela de 27-03-2024 10:29:59.webm](https://github.com/oxeanbits/pluto_grid/assets/51444228/e412ddb9-562a-4b21-a992-065b666d2eb4)

