### PR TITLE
Refactor body scrollbars into external wrapper

### DIFF
--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -680,7 +680,7 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
                 /// Body columns and rows.
                 LayoutId(
                   id: _StackName.bodyRows,
-                  child: PlutoBodyRows(_stateManager),
+                  child: PlutoBodyRowsWithScrollbar(_stateManager),
                 ),
                 LayoutId(
                   id: _StackName.bodyColumns,

--- a/lib/src/ui/pluto_body_rows.dart
+++ b/lib/src/ui/pluto_body_rows.dart
@@ -4,28 +4,25 @@ import 'package:pluto_grid/pluto_grid.dart';
 import '../helper/platform_helper.dart';
 import 'ui.dart';
 
-class PlutoBodyRows extends PlutoStatefulWidget {
+class PlutoBodyRowsWithScrollbar extends StatefulWidget {
   final PlutoGridStateManager stateManager;
 
-  const PlutoBodyRows(
+  const PlutoBodyRowsWithScrollbar(
     this.stateManager, {
     super.key,
   });
 
   @override
-  PlutoBodyRowsState createState() => PlutoBodyRowsState();
+  State<PlutoBodyRowsWithScrollbar> createState() =>
+      _PlutoBodyRowsWithScrollbarState();
 }
 
-class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
-  List<PlutoColumn> _columns = [];
-
-  List<PlutoRow> _rows = [];
-
+class _PlutoBodyRowsWithScrollbarState
+    extends State<PlutoBodyRowsWithScrollbar> {
   late final ScrollController _verticalScroll;
 
   late final ScrollController _horizontalScroll;
 
-  @override
   PlutoGridStateManager get stateManager => widget.stateManager;
 
   @override
@@ -33,38 +30,17 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
     super.initState();
 
     _horizontalScroll = stateManager.scroll.horizontal!.addAndGet();
-
     stateManager.scroll.setBodyRowsHorizontal(_horizontalScroll);
 
     _verticalScroll = stateManager.scroll.vertical!.addAndGet();
-
     stateManager.scroll.setBodyRowsVertical(_verticalScroll);
-
-    updateState(PlutoNotifierEventForceUpdate.instance);
   }
 
   @override
   void dispose() {
     _verticalScroll.dispose();
-
     _horizontalScroll.dispose();
-
     super.dispose();
-  }
-
-  @override
-  void updateState(PlutoNotifierEvent event) {
-    forceUpdate();
-
-    _columns = _getColumns();
-
-    _rows = stateManager.refRows;
-  }
-
-  List<PlutoColumn> _getColumns() {
-    return stateManager.showFrozenColumn == true
-        ? stateManager.bodyColumns
-        : stateManager.columns;
   }
 
   @override
@@ -90,30 +66,88 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
       radius: scrollbarConfig.scrollbarRadius,
       radiusWhileDragging: scrollbarConfig.scrollbarRadiusWhileDragging,
       longPressDuration: scrollbarConfig.longPressDuration,
-      child: SingleChildScrollView(
-        controller: _horizontalScroll,
-        scrollDirection: Axis.horizontal,
-        physics: const ClampingScrollPhysics(),
-        child: CustomSingleChildLayout(
-          delegate: ListResizeDelegate(stateManager, _columns),
-          child: ListView.builder(
-            controller: _verticalScroll,
-            scrollDirection: Axis.vertical,
-            physics: const ClampingScrollPhysics(),
-            itemCount: _rows.length,
-            itemExtent: stateManager.rowTotalHeight,
-            addRepaintBoundaries: false,
-            itemBuilder: (ctx, i) {
-              return PlutoBaseRow(
-                key: ValueKey('body_row_${_rows[i].key}'),
-                rowIdx: i,
-                row: _rows[i],
-                columns: _columns,
-                stateManager: stateManager,
-                visibilityLayout: true,
-              );
-            },
-          ),
+      child: PlutoBodyRows(
+        stateManager,
+        verticalScroll: _verticalScroll,
+        horizontalScroll: _horizontalScroll,
+      ),
+    );
+  }
+}
+
+class PlutoBodyRows extends PlutoStatefulWidget {
+  final PlutoGridStateManager stateManager;
+
+  final ScrollController verticalScroll;
+
+  final ScrollController horizontalScroll;
+
+  const PlutoBodyRows(
+    this.stateManager, {
+    required this.verticalScroll,
+    required this.horizontalScroll,
+    super.key,
+  });
+
+  @override
+  PlutoBodyRowsState createState() => PlutoBodyRowsState();
+}
+
+class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
+  List<PlutoColumn> _columns = [];
+
+  List<PlutoRow> _rows = [];
+
+  @override
+  PlutoGridStateManager get stateManager => widget.stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    updateState(PlutoNotifierEventForceUpdate.instance);
+  }
+
+  @override
+  void updateState(PlutoNotifierEvent event) {
+    forceUpdate();
+
+    _columns = _getColumns();
+
+    _rows = stateManager.refRows;
+  }
+
+  List<PlutoColumn> _getColumns() {
+    return stateManager.showFrozenColumn == true
+        ? stateManager.bodyColumns
+        : stateManager.columns;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      controller: widget.horizontalScroll,
+      scrollDirection: Axis.horizontal,
+      physics: const ClampingScrollPhysics(),
+      child: CustomSingleChildLayout(
+        delegate: ListResizeDelegate(stateManager, _columns),
+        child: ListView.builder(
+          controller: widget.verticalScroll,
+          scrollDirection: Axis.vertical,
+          physics: const ClampingScrollPhysics(),
+          itemCount: _rows.length,
+          itemExtent: stateManager.rowTotalHeight,
+          addRepaintBoundaries: false,
+          itemBuilder: (ctx, i) {
+            return PlutoBaseRow(
+              key: ValueKey('body_row_${_rows[i].key}'),
+              rowIdx: i,
+              row: _rows[i],
+              columns: _columns,
+              stateManager: stateManager,
+              visibilityLayout: true,
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- introduce a PlutoBodyRowsWithScrollbar wrapper that manages the row scroll controllers
- pass the managed controllers down to PlutoBodyRows so the scrollable content is separated from the scrollbar painting
- update the grid layout to compose the new wrapper and keep existing body layout intact

## Testing
- flutter test test/scenario/layout/layout_test.dart *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68ef9daa456883309f15bd3c10cc46f7