### PR TITLE
Reserve dedicated corner space for PlutoGrid scrollbars

### DIFF
--- a/lib/src/ui/pluto_body_rows.dart
+++ b/lib/src/ui/pluto_body_rows.dart
@@ -70,6 +70,8 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
   @override
   Widget build(BuildContext context) {
     final scrollbarConfig = stateManager.configuration.scrollbar;
+    final scrollbarSpacer =
+        scrollbarConfig.hoverWidth + scrollbarConfig.crossAxisMargin;
 
     return PlutoScrollbar(
       verticalController:
@@ -90,29 +92,35 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
       radius: scrollbarConfig.scrollbarRadius,
       radiusWhileDragging: scrollbarConfig.scrollbarRadiusWhileDragging,
       longPressDuration: scrollbarConfig.longPressDuration,
-      child: SingleChildScrollView(
-        controller: _horizontalScroll,
-        scrollDirection: Axis.horizontal,
-        physics: const ClampingScrollPhysics(),
-        child: CustomSingleChildLayout(
-          delegate: ListResizeDelegate(stateManager, _columns),
-          child: ListView.builder(
-            controller: _verticalScroll,
-            scrollDirection: Axis.vertical,
-            physics: const ClampingScrollPhysics(),
-            itemCount: _rows.length,
-            itemExtent: stateManager.rowTotalHeight,
-            addRepaintBoundaries: false,
-            itemBuilder: (ctx, i) {
-              return PlutoBaseRow(
-                key: ValueKey('body_row_${_rows[i].key}'),
-                rowIdx: i,
-                row: _rows[i],
-                columns: _columns,
-                stateManager: stateManager,
-                visibilityLayout: true,
-              );
-            },
+      child: Padding(
+        padding: EdgeInsets.only(
+          right: scrollbarSpacer,
+          bottom: scrollbarSpacer,
+        ),
+        child: SingleChildScrollView(
+          controller: _horizontalScroll,
+          scrollDirection: Axis.horizontal,
+          physics: const ClampingScrollPhysics(),
+          child: CustomSingleChildLayout(
+            delegate: ListResizeDelegate(stateManager, _columns),
+            child: ListView.builder(
+              controller: _verticalScroll,
+              scrollDirection: Axis.vertical,
+              physics: const ClampingScrollPhysics(),
+              itemCount: _rows.length,
+              itemExtent: stateManager.rowTotalHeight,
+              addRepaintBoundaries: false,
+              itemBuilder: (ctx, i) {
+                return PlutoBaseRow(
+                  key: ValueKey('body_row_${_rows[i].key}'),
+                  rowIdx: i,
+                  row: _rows[i],
+                  columns: _columns,
+                  stateManager: stateManager,
+                  visibilityLayout: true,
+                );
+              },
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- add dedicated bottom/right padding around the body scroll views so vertical and horizontal scrollbar tracks no longer overlap row content
- compute the spacer from scrollbar hover width and cross-axis margin, so the reserved area follows scrollbar configuration
- keep existing scrollbar drag/hover behavior intact while making the scrollable area boundaries clearer

## Why
Previously, the custom scrollbar was painted on top of the grid body. This made both scrollbars feel coupled to content and caused overlap with cells near the trailing edges. Reserving explicit corner space decouples the bars from content and makes the scroll extent easier to perceive.

## Files changed
- `lib/src/ui/pluto_body_rows.dart`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f3f0052b48330ad3a3d10433f5182)